### PR TITLE
Add ability to do dry runs

### DIFF
--- a/lib/tango/met_and_meet.rb
+++ b/lib/tango/met_and_meet.rb
@@ -19,13 +19,20 @@ module Tango
         log "already met."
       else
         log "not already met."
-        instance_eval(&meet_block)
-        if instance_eval(&met_block)
-          log "met."
-        else
-          raise CouldNotMeetError
+
+        if !dry_run?
+          instance_eval(&meet_block)
+          if instance_eval(&met_block)
+            log "met."
+          else
+            raise CouldNotMeetError
+          end
         end
       end
+    end
+
+    def dry_run?
+      !!ENV['TANGO_DRY_RUN']
     end
 
   end

--- a/spec/met_and_meet_spec.rb
+++ b/spec/met_and_meet_spec.rb
@@ -89,6 +89,43 @@ module Tango
       expect { klass.new.a }.should raise_error(CouldNotMeetError)
     end
 
+    context "with TANGO_DRY_RUN set" do
+      before do
+        ENV['TANGO_DRY_RUN'] = 'true'
+      end
+
+      it "should not execute meet blocks if met passes" do
+        met_block_calls  = 0
+        meet_block_calls = 0
+
+        @stub.new.instance_eval do
+          met? do
+            met_block_calls += 1
+            true
+          end
+          meet { meet_block_calls += 1 }
+        end
+
+        met_block_calls.should  == 1
+        meet_block_calls.should == 0
+      end
+
+      it "should not execute meet blocks if met fails" do
+        met_block_calls  = 0
+        meet_block_calls = 0
+
+        @stub.new.instance_eval do
+          met? do
+            met_block_calls += 1
+            false
+          end
+          meet { meet_block_calls += 1 }
+        end
+
+        met_block_calls.should  == 1
+        meet_block_calls.should == 0
+      end
+    end
   end
 end
 


### PR DESCRIPTION
Set TANGO_DRY_RUN to do dry runs. Doesn't work for steps that don't have meet blocks though.
