### PR TITLE
Implement met! which ensures the condition is NOT met before meet is called

### DIFF
--- a/lib/tango/met_and_meet.rb
+++ b/lib/tango/met_and_meet.rb
@@ -1,6 +1,7 @@
 module Tango
   class CouldNotMeetError   < RuntimeError; end
   class MeetWithoutMetError < RuntimeError; end
+  class MustNotMeetError    < RuntimeError; end
 
   module MetAndMeet
 
@@ -8,25 +9,46 @@ module Tango
       @met_block = met_block
     end
 
+    def met!(&must_not_meet_block)
+      @must_not_meet_block = must_not_meet_block
+    end
+
     def meet(&meet_block)
-      # Cache the met block in case something inside the meet
+      # Cache the met blocks in case something inside the meet
       # block calls another step with another met block:
       met_block = @met_block
+      must_not_meet_block = @must_not_meet_block
 
-      raise MeetWithoutMetError if met_block.nil?
+      raise MeetWithoutMetError if met_block.nil? && must_not_meet_block.nil?
 
+      met_with_meet(met_block, meet_block) if met_block
+      must_not_meet_with_meet(must_not_meet_block, meet_block) if must_not_meet_block
+    end
+
+    protected
+
+    def met_with_meet(met_block, meet_block)
       if instance_eval(&met_block)
         log "already met."
       else
-        log "not already met."
-        instance_eval(&meet_block)
-        if instance_eval(&met_block)
-          log "met."
-        else
-          raise CouldNotMeetError
-        end
+        meet_and_ensure_met(met_block, meet_block)
       end
     end
 
+    def must_not_meet_with_meet(met_block, meet_block)
+      raise MustNotMeetError if instance_eval(&met_block)
+      meet_and_ensure_met(met_block, meet_block)
+    end
+
+    def meet_and_ensure_met(met_block, meet_block)
+      log "not already met."
+      instance_eval(&meet_block)
+
+      if instance_eval(&met_block)
+        log "met."
+      else
+        raise CouldNotMeetError
+      end
+    end
   end
 end

--- a/spec/logger_spec.rb
+++ b/spec/logger_spec.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 require 'tango'
 require 'stringio'
 


### PR DESCRIPTION
Not 100% sure on the name `met!`, could possibly just name the thing `must_not_meet`?

Use case:

``` ruby
class Server < Tango::Runner
  def initialize(server_name)
    @server_name = server_name
    @cloud_api = SomeCloudApi.new
  end

  step :build do
    met! { @cloud_api.has_server?(@server_name) }
    meet { @cloud_api.build_server(...) }
  end
end
```
