### PR TITLE
Style and colour improvements.

### DIFF
--- a/lib/tango/logger.rb
+++ b/lib/tango/logger.rb
@@ -1,7 +1,20 @@
 # coding: utf-8
 
 module Tango
+  module TermANSIColorStubs
+    [:red, :green, :yellow].each do |color|
+      define_method(color) { |str| str }
+    end
+  end
+
   class Logger
+    begin
+      require 'term/ansicolor'
+      include Term::ANSIColor
+    rescue LoadError
+      include TermANSIColorStubs
+    end
+
     def self.instance
       @logger ||= Logger.new
     end
@@ -12,18 +25,18 @@ module Tango
     end
 
     def begin_step(step_name)
-      log "#{step_name} {"
+      log "#{yellow(step_name)} {"
       @depth += 1
     end
 
     def step_met(step_name)
       @depth -= 1
-      log "} √ #{step_name}"
+      log "} #{green("√ #{step_name}")}"
     end
 
     def step_not_met(step_name)
       @depth -= 1
-      log "} ✕ #{step_name}\n\n"
+      log "} #{red("✕ #{step_name}")}\n\n"
     end
 
     def log(message)

--- a/lib/tango/logger.rb
+++ b/lib/tango/logger.rb
@@ -49,7 +49,6 @@ module Tango
 
   private
 
-
     def indent
       "  " * @depth
     end

--- a/lib/tango/logger.rb
+++ b/lib/tango/logger.rb
@@ -11,14 +11,19 @@ module Tango
       @depth = 0
     end
 
-    def enter(step_name)
+    def begin_step(step_name)
       log "#{step_name} {"
       @depth += 1
     end
 
-    def leave(step_name)
+    def step_met(step_name)
       @depth -= 1
       log "} √ #{step_name}"
+    end
+
+    def step_not_met(step_name)
+      @depth -= 1
+      log "} ✕ #{step_name}\n\n"
     end
 
     def log(message)
@@ -30,6 +35,7 @@ module Tango
     end
 
   private
+
 
     def indent
       "  " * @depth

--- a/lib/tango/runner.rb
+++ b/lib/tango/runner.rb
@@ -20,9 +20,15 @@ module Tango
       define_method(step_name) do |*args|
         description = step_description(step_name, args)
 
-        logger.enter(description)
-        result = instance_exec(*args, &block)
-        logger.leave(description)
+        logger.begin_step(description)
+        begin
+          result = instance_exec(*args, &block)
+        rescue StandardError
+          logger.step_not_met(description)
+          raise
+        else
+          logger.step_met(description)
+        end
 
         result
       end

--- a/spec/logger_spec.rb
+++ b/spec/logger_spec.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 require 'tango'
 require 'stringio'
 
@@ -9,22 +11,27 @@ module Tango
       @logger = Logger.new(@io)
     end
 
-    it "should output the step name when entering a step" do
-      @logger.enter("example step")
+    it "should output the step name when beginning a step" do
+      @logger.begin_step("example step")
       @io.string.should == "example step {\n"
     end
 
-    it "should output a closing brace when leaving a step" do
-      @logger.enter("example step")
-      @logger.leave("example step")
+    it "should output a closing brace when a step is met" do
+      @logger.begin_step("example step")
+      @logger.step_met("example step")
       @io.string.should == "example step {\n} √ example step\n"
     end
 
-    it "should indent nested steps" do
-      @logger.enter("outer step")
-      @logger.enter("inner step")
-      @io.string.should == "outer step {\n  inner step {\n"
+    it "should output a closing brace when a step is not met" do
+      @logger.begin_step("example step")
+      @logger.step_not_met("example step")
+      @io.string.should == "example step {\n} ✕ example step\n\n"
     end
 
+    it "should indent nested steps" do
+      @logger.begin_step("outer step")
+      @logger.begin_step("inner step")
+      @io.string.should == "outer step {\n  inner step {\n"
+    end
   end
 end

--- a/spec/runner_spec.rb
+++ b/spec/runner_spec.rb
@@ -5,7 +5,6 @@ class StubbedLogger
   def step_not_met(name); end
   def step_met(name); end
   def log(message); end
-
 end
 
 class StubbedRunner < Tango::Runner

--- a/spec/runner_spec.rb
+++ b/spec/runner_spec.rb
@@ -1,9 +1,11 @@
 require 'tango'
 
 class StubbedLogger
-  def enter(name); end
-  def leave(name); end
+  def begin_step(name); end
+  def step_not_met(name); end
+  def step_met(name); end
   def log(message); end
+
 end
 
 class StubbedRunner < Tango::Runner


### PR DESCRIPTION
Two changes here, the first ensures that a step is closed when it fails, e.g:

```
MyRunner.install {
  not already met.
} ✕ MyRunner.install # Not printed prior to my change

/Users/ian/Projects/tango/lib/tango/met_and_meet.rb:26:in `meet': Tango::CouldNotMeetError
<rest of backtrace>
```

The second adds a little colour. The first `MyRunner.install` is in yellow, and the closing `√/✕ MyRunner.install` is in either red or green.
