### PR TITLE
Show progress bar output for meet if :progress => true

### DIFF
--- a/lib/tango/logger.rb
+++ b/lib/tango/logger.rb
@@ -2,6 +2,8 @@
 
 module Tango
   class Logger
+    attr_reader :depth
+
     def self.instance
       @logger ||= Logger.new
     end

--- a/lib/tango/met_and_meet.rb
+++ b/lib/tango/met_and_meet.rb
@@ -8,7 +8,7 @@ module Tango
       @met_block = met_block
     end
 
-    def meet(&meet_block)
+    def meet(options = {}, &meet_block)
       # Cache the met block in case something inside the meet
       # block calls another step with another met block:
       met_block = @met_block
@@ -19,7 +19,13 @@ module Tango
         log "already met."
       else
         log "not already met."
-        instance_eval(&meet_block)
+
+        if options[:progress]
+          ProgressBar.show(self) { instance_eval(&meet_block) }
+        else
+          instance_eval(&meet_block)
+        end
+
         if instance_eval(&met_block)
           log "met."
         else
@@ -27,6 +33,5 @@ module Tango
         end
       end
     end
-
   end
 end

--- a/lib/tango/progress_bar.rb
+++ b/lib/tango/progress_bar.rb
@@ -1,0 +1,73 @@
+# encoding: utf-8
+
+module Tango
+  class MustImplementProgressMethodError < RuntimeError; end
+
+  class ProgressBar
+    WIDTH = 40
+    REFRESH_RATE = 0.2
+
+     module TermANSIColorStubs
+       def green(str);
+         str
+       end
+     end
+
+    begin
+       require 'term/ansicolor'
+       include Term::ANSIColor
+     rescue LoadError
+       include TermANSIColorStubs
+     end
+
+    def self.show(runner, &block)
+      Thread.abort_on_exception = true
+      new(runner, block).start
+    end
+
+    def initialize(runner, block)
+      @runner = runner
+      @block = block
+      @buf = ''
+      ensure_runner_responds_to_percentage
+    end
+
+    def start
+      @thread = Thread.new do
+        loop do
+          progress = @runner.progress
+          @runner.log_raw(progress_bar(progress))
+          break if @stop || progress.to_i == 100
+          sleep REFRESH_RATE
+          clear
+        end
+      end
+
+      @block.call ensure stop
+    end
+
+    def stop
+      @stop = true
+      @thread.join if @thread
+      clear
+    end
+
+    protected
+
+    def clear
+      @runner.log_raw("\b \b" * (@buf.size * 3))
+    end
+
+    def progress_bar(progress)
+      @buf = "#{' ' * @runner.logger.depth} |"
+      blocks = ((WIDTH * progress.to_f) / 100.0).floor
+      @buf += green('❚') * blocks
+      @buf += ' ' * (WIDTH - blocks)
+      @buf += "| #{progress.to_i}%"
+    end
+
+    def ensure_runner_responds_to_percentage
+      raise MustImplementProgressMethodError if !@runner.respond_to?(:progress)
+    end
+  end
+end

--- a/lib/tango/runner.rb
+++ b/lib/tango/runner.rb
@@ -4,6 +4,7 @@ require 'tango/helpers/file_manipulation_helpers'
 require 'tango/delegate'
 require 'tango/fetch'
 require 'tango/met_and_meet'
+require 'tango/progress_bar'
 require 'tango/shell'
 
 module Tango

--- a/spec/logger_spec.rb
+++ b/spec/logger_spec.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 require 'tango'
 require 'stringio'
 
@@ -26,5 +28,9 @@ module Tango
       @io.string.should == "outer step {\n  inner step {\n"
     end
 
+    it 'exposes the depth' do
+      @logger.enter("outer step")
+      @logger.depth.should == 1
+    end
   end
 end

--- a/spec/met_and_meet_spec.rb
+++ b/spec/met_and_meet_spec.rb
@@ -89,6 +89,14 @@ module Tango
       expect { klass.new.a }.should raise_error(CouldNotMeetError)
     end
 
+    it 'starts the progress bar if the :progress option is true' do
+      runner = @stub.new
+      ProgressBar.should_receive(:show).with(runner).and_yield
+      runner.instance_eval do
+        met? { @met }
+        meet(:progress => true) { @met = true }
+      end
+    end
   end
 end
 

--- a/spec/progress_bar_spec.rb
+++ b/spec/progress_bar_spec.rb
@@ -1,0 +1,38 @@
+# encoding: utf-8
+
+require 'tango'
+
+describe Tango::ProgressBar do
+  class Tango::ProgressBar
+    def green(str); str end
+  end
+
+  let(:logger) { stub(:depth => 0) }
+  let(:runner) { stub(:progress => 100, :logger => logger, :log_raw => nil) }
+  subject { Tango::ProgressBar.show(runner) { } }
+
+  it 'ensures the runner implements the progress method' do
+    expect do
+      Tango::ProgressBar.show(stub) { }
+    end.should raise_error(Tango::MustImplementProgressMethodError)
+  end
+
+  it 'calls the given block' do
+    @called = false
+    block = lambda { @called = true }
+    Tango::ProgressBar.show(runner, &block)
+    @called.should be_true
+  end
+
+  it 'logs the progress' do
+    runner.stub(:progress => 50)
+    runner.should_receive(:log_raw).with(' |❚❚❚❚❚❚❚❚❚❚❚❚❚❚❚❚❚❚❚❚                    | 50%')
+    Tango::ProgressBar.show(runner) { }
+  end
+
+  it 'clears the progress bar when complete' do
+    runner.stub(:progress => 100)
+    runner.should_receive(:log_raw).with("\b \b" * (48 * 3))
+    Tango::ProgressBar.show(runner) { }
+  end
+end


### PR DESCRIPTION
This add the ability to show a progress bar while `meet` is being executed.

```
MyRunner.install {
  not already met.
  |❚❚❚❚❚❚❚❚❚❚❚❚❚❚❚❚❚❚❚❚❚❚❚❚❚❚❚❚❚❚          | 76%
```

You pass `:progress => true` to `meet` and the implement the `progress` method in your runner.

After the block is complete the progress bar is cleared:

```
MyRunner.install {
  not already met.
  met.                                           
} √ MyRunner.install
```

The Term::ANSIColor fun can be extracted into a common module to share with the Logger once PR #9 is merged.
