### PR TITLE
Add Tango::Runner#perform for running all steps in the order they were defined.

### DIFF
--- a/lib/tango/runner.rb
+++ b/lib/tango/runner.rb
@@ -16,7 +16,18 @@ module Tango
     include Shell
     include Helpers::FileManipulationHelpers
 
+    def self.steps
+      @steps ||= []
+    end
+
+    def self.perform(*args)
+      runner = new(*args)
+      steps.each { |step| runner.send(step) }
+      runner
+    end
+
     def self.step(step_name, &block)
+      steps << step_name
       define_method(step_name) do |*args|
         description = step_description(step_name, args)
 

--- a/spec/logger_spec.rb
+++ b/spec/logger_spec.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 require 'tango'
 require 'stringio'
 

--- a/spec/runner_spec.rb
+++ b/spec/runner_spec.rb
@@ -73,5 +73,34 @@ module Tango
       end
     end
 
+    describe 'perform' do
+      class PerformRunner < StubbedRunner
+        def history
+          @history ||= []
+        end
+
+        step :first do
+          history << :first
+        end
+
+        step :last do
+          history << :last
+        end
+      end
+
+      it 'passes the args to the constructor' do
+        arg = stub
+        runner = PerformRunner.new
+        PerformRunner.should_receive(:new).with(arg).and_return(runner)
+        PerformRunner.perform(arg)
+      end
+
+      it 'performs steps in the order they were defined' do
+        runner = PerformRunner.new
+        PerformRunner.stub(:new => runner)
+        PerformRunner.perform
+        runner.history.should == [:first, :last]
+      end
+    end
   end
 end


### PR DESCRIPTION
Given a more complex runner which contains multiple steps, e.g:

``` ruby
god = God.new(:environment => ENVIRONMENT)
god.install_gem
god.install_init_script
god.install_watchers
```

My top-level "app server installer" is quickly growing with the calls to individual steps. I don't really need to know the _individual_ steps involved when installing God from this level, only that God installation is a part of the process.

This PR adds a class-level `perform` method to Runner, so the above example would become:

``` ruby
God.perform(:environment => ENVIRONMENT)
```

It runs each steps in the order they are defined. Arguments are passed through to the runner's constructor.
