### PR TITLE
Add ConfigFiles#template for easily opening a relative file.

### DIFF
--- a/lib/tango/config_files.rb
+++ b/lib/tango/config_files.rb
@@ -5,10 +5,15 @@ module Tango
   module ConfigFiles
 
     def write(path, contents, permissions = nil)
-      contents = unindent(contents)
+      contents = contents.is_a?(File) ? contents.read : unindent(contents)
       contents = ERB.new(contents).result(binding)
       File.open(path, "w") {|file| file.write(contents) }
       FileUtils.chmod(permissions, path) if permissions
+    end
+
+    def template(path)
+      caller_file = caller.first.split(':').first
+      File.open(File.join(File.dirname(caller_file), path), 'r')
     end
 
   private
@@ -17,6 +22,5 @@ module Tango
       indent = /^ */.match(text)
       text.gsub(/^#{indent}/, "")
     end
-
   end
 end

--- a/spec/config_files_spec.rb
+++ b/spec/config_files_spec.rb
@@ -36,6 +36,14 @@ module Tango
       File.read("tmp/example.conf").should == "Goodbye\n  cruel\nworld!\n"
     end
 
+    it 'does not unindent contents read from an File' do
+      File.open('tmp/template', 'w') do |fd|
+        fd.write('    England!')
+      end
+      @stub.write('tmp/example.conf', File.open('tmp/template', 'r'))
+      File.read('tmp/example.conf').should == '    England!'
+    end
+
     it "should render ERB in the contents" do
       @stub.write("tmp/example.conf", "Hello, <%= 'world!' %>")
       File.read("tmp/example.conf").should == "Hello, world!"
@@ -46,6 +54,13 @@ module Tango
       @stub.write("tmp/example.conf", "Hello, <%= @world %>")
       File.read("tmp/example.conf").should == "Hello, world!"
     end
-    
+
+    it 'opens an ERB template relative to the runner file' do
+      tmp = File.join(File.dirname(__FILE__), '../tmp')
+      caller_path = File.join(tmp, 'runner.rb')
+      @stub.should_receive(:caller).and_return(["#{caller_path}:80:in `your face'"])
+      FileUtils.touch(File.join(tmp, 'config.sh.erb'))
+      @stub.template('config.sh.erb').path.should == File.join(File.dirname(caller_path), 'config.sh.erb')
+    end
   end
 end

--- a/spec/logger_spec.rb
+++ b/spec/logger_spec.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 require 'tango'
 require 'stringio'
 


### PR DESCRIPTION
Me again!

In my steps repo, I have a structure like this:

```
tango-steps/
  runners/
    god.rb
    god/
      init.sh.erb
```

I want to use the `write` helper from `ConfigFiles`, but figuring out the path to init.sh.erb is a little annoying.

`template` will return an open File handle to a file relative to the path of the runner file. I can now call `write` like this:

``` ruby
write('/etc/init.d/god', template('god/init.sh.erb'))
```
