### PR TITLE
Integrate User context and Shell.

### DIFF
--- a/lib/tango/contexts.rb
+++ b/lib/tango/contexts.rb
@@ -3,3 +3,24 @@ require 'tango/contexts/directory'
 require 'tango/contexts/helpers'
 require 'tango/contexts/umask'
 require 'tango/contexts/user'
+
+module Tango
+  module Contexts
+    class NotInContextError < StandardError; end
+
+    def current
+      Thread.current[:tango_contexts] ||= []
+    end
+    module_function :current
+
+    def context_for(name)
+      current.reverse.find { |context| canonical_name(context) == name.to_s }
+    end
+    module_function :context_for
+
+    def canonical_name(context)
+      context.class.name.split('::').last.gsub(/([a-z])([A-Z])/, '\1_\2').downcase
+    end
+    module_function :canonical_name
+  end
+end

--- a/lib/tango/contexts/chain.rb
+++ b/lib/tango/contexts/chain.rb
@@ -5,7 +5,7 @@ module Tango
     class Chain
 
       include Helpers
-    
+
       def initialize
         @contexts = []
       end
@@ -22,11 +22,18 @@ module Tango
     private
 
       def call_in_contexts
-        @contexts.each {|context| context.enter }
         begin
+          @contexts.each do |context|
+            Contexts.current.push(context)
+            context.enter
+          end
+
           yield
         ensure
-          @contexts.reverse.each {|context| context.leave }
+          @contexts.size.times do
+            context = Contexts.current.pop
+            context.leave if context
+          end
         end
       end
 

--- a/lib/tango/contexts/directory.rb
+++ b/lib/tango/contexts/directory.rb
@@ -1,6 +1,7 @@
 module Tango
   module Contexts
     class Directory
+      attr_reader :directory
 
       def initialize(directory)
         @directory = directory

--- a/lib/tango/contexts/umask.rb
+++ b/lib/tango/contexts/umask.rb
@@ -1,6 +1,7 @@
 module Tango
   module Contexts
     class Umask
+      attr_reader :umask
 
       def initialize(umask)
         @umask = umask

--- a/lib/tango/contexts/user.rb
+++ b/lib/tango/contexts/user.rb
@@ -1,9 +1,10 @@
 module Tango
   module Contexts
     class User
+      attr_reader :username
 
       def initialize(username)
-        @username = username
+        @username = username.to_s
       end
 
       def enter

--- a/spec/contexts/chain_spec.rb
+++ b/spec/contexts/chain_spec.rb
@@ -13,7 +13,7 @@ module Tango::Contexts
           @in_context = false
         end
 
-        def enter 
+        def enter
           @in_context = true
         end
 
@@ -52,6 +52,17 @@ module Tango::Contexts
         Chain.new.in_context(@context) { raise "Uh oh" }
       }.should raise_error("Uh oh")
       @context.should_not be_in_context
+    end
+
+    it 'adds the context into the list of current contexts' do
+      Chain.new.in_context(@context) do
+        Tango::Contexts.current.include?(@context).should be_true
+      end
+    end
+
+    it 'removes the context from the list of current contexts' do
+      Chain.new.in_context(@context) { }
+      Tango::Contexts.current.include?(@context).should be_false
     end
 
     describe "when chaining contexts" do

--- a/spec/contexts/directory_spec.rb
+++ b/spec/contexts/directory_spec.rb
@@ -2,7 +2,7 @@ require 'tango'
 
 module Tango::Contexts
   describe Directory do
-    
+
     before do
       stub_class = Class.new do
         include Helpers
@@ -31,6 +31,9 @@ module Tango::Contexts
       Dir.getwd.should == old_directory
     end
 
+    it 'exposes the directory' do
+      Directory.new('/foo').directory.should == '/foo'
+    end
   end
 end
 

--- a/spec/contexts/umask_spec.rb
+++ b/spec/contexts/umask_spec.rb
@@ -29,5 +29,8 @@ module Tango::Contexts
       File.umask.should == old_umask
     end
 
+    it 'exposes the umask' do
+      Umask.new(0644).umask.should == 0644
+    end
   end
 end

--- a/spec/contexts/user_spec.rb
+++ b/spec/contexts/user_spec.rb
@@ -1,0 +1,9 @@
+require 'tango'
+
+module Tango::Contexts
+  describe User do
+    it 'exposes the username' do
+      User.new('amy').username.should == 'amy'
+    end
+  end
+end

--- a/spec/contexts_spec.rb
+++ b/spec/contexts_spec.rb
@@ -1,0 +1,29 @@
+require 'tango'
+
+module Tango
+  describe Contexts do
+    class Contexts::TestContext
+      def enter; end
+      def leave; end
+    end
+
+    let(:context) { Contexts::TestContext.new }
+
+    it 'returns the context identified by the canonical name' do
+      Contexts::Chain.new.in_context(context) do
+        Contexts.context_for(:test_context).should == context
+      end
+    end
+
+    it 'returns nil when not in the given context' do
+      Contexts.context_for(:test_context).should be_nil
+    end
+
+    it 'finds the inner most context first' do
+      outter_context = Contexts::TestContext.new
+      Contexts::Chain.new.in_context(outter_context).in_context(context) do
+        Contexts.context_for(:test_context).should == context
+      end
+    end
+  end
+end

--- a/spec/logger_spec.rb
+++ b/spec/logger_spec.rb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 require 'tango'
 require 'stringio'
 

--- a/spec/shell_spec.rb
+++ b/spec/shell_spec.rb
@@ -67,5 +67,55 @@ module Tango
       end
     end
 
+    context 'as a user' do
+      class Context
+        def enter; end
+        def leave; end
+      end
+
+      class User < Context
+        def username; 'amy' end
+      end
+
+      class Directory < Context
+        def directory; '/foo' end
+      end
+
+      class Umask < Context
+        def umask; '0644' end
+      end
+
+      let(:user_context) { User.new }
+      let(:dir_context) { Directory.new }
+      let(:umask_context) { Umask.new }
+      let(:klass) { @stub_class.new }
+      let(:chain) { Contexts::Chain.new }
+
+      before do
+        klass.stub(:fork_and_exec => [0, stub(:pipe).as_null_object])
+        klass.stub(:collect_output)
+        Process.stub(:waitpid)
+      end
+
+      it 'executes the command in a new login shell' do
+        klass.should_receive(:fork_and_exec).with('su', {}, '-l', '-c', "ls -al /dir", 'amy')
+        chain.in_context(user_context) { klass.shell('ls', '-al', '/dir') }
+      end
+
+      it 'preserves the directory context' do
+        klass.should_receive(:fork_and_exec).with('su', {}, '-l', '-c', "cd /foo && id", 'amy')
+        chain.in_context(user_context).in_context(dir_context) { klass.shell('id') }
+      end
+
+      it 'preserves the umask context' do
+        klass.should_receive(:fork_and_exec).with('su', {}, '-l', '-c', "umask 0644 && id", 'amy')
+        chain.in_context(user_context).in_context(umask_context) { klass.shell('id') }
+      end
+
+      it 'preserves many contexts' do
+        klass.should_receive(:fork_and_exec).with('su', {}, '-l', '-c', "cd /foo && umask 0644 && id", 'amy')
+        chain.in_context(user_context).in_context(umask_context).in_context(dir_context) { klass.shell('id') }
+      end
+    end
   end
 end


### PR DESCRIPTION
Shell commands are executed within the context of the user when inside the scope of `as_user`.

I tried the approach of keeping open a persistent shell and writing/reading through pipes, though it turned out to be more complex than I'd like. Specifically there's no way to get the return status of a command without restoring to hacks.

The approach implemented here simply uses a new login shell for each command. Slower, but not enough to be any concern.

The Directory and Umask contexts are also carried over into the new shell.
